### PR TITLE
Use parseFoo/renderFoo function names, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@
 
 This library provides a type representing [Amazon Resource Names
 (ARNs)](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html),
-and parsing/unparsing functions for them. The provided optics make it
-very convenient to rewrite parts of ARNs.
+and parsing/unparsing functions for them. When combined with
+[`generic-lens`](https://hackage.haskell.org/package/generic-lens) or
+[`generic-optics`](https://hackage.haskell.org/package/generic-optics),
+the provided prisms make it very convenient to rewrite parts of ARNs.
 
 Start reading at the `Network.AWS.ARN` module, which defines the core
 data type and includes some examples.
@@ -30,56 +32,49 @@ add a new resource:
 
 2. Define a record `Foo` to represent the parsed resource part of an
    ARN, and derive (at least) `Eq`, `Ord`, `Hashable`, `Show` and
-   `Generic`. Also generate lenses for its fields:
+   `Generic`:
 
    ```haskell
    data Function = Function
-   { _fName :: Text,
-     _fQualifier :: Maybe Text
+   { name :: Text,
+     qualifier :: Maybe Text
    }
    deriving (Eq, Ord, Hashable, Show, Generic)
-
-   $(makeLenses ''Function)
    ```
 
-3. Define `toFoo` and `fromFoo` functions that attempt to parse and
-   unparse the resource part of the ARN:
+3. Define `parseFoo` and `renderFoo` functions that attempt to parse
+   and unparse the resource part of the ARN:
 
    ```haskell
-   toFunction :: Text -> Maybe Function
-   fromFunction :: Function -> Text
+   parseFunction :: Text -> Maybe Function
+   renderFunction :: Function -> Text
    ```
-
-   **Remark:** While these names sound backwards compared to
-   `fromText` and `toText`, it means we can have multiple parsing
-   functions in a single service's module.
 
    **Remark:** If you need to write tests for these functions, the
    corresponding module should live at
    `test/Network/AWS/ARN/SomeAWSService/Test.hs`
 
 4. Define a `_Foo` `Prism'` that combines the parsing/unparsing
-   functions above:
+   functions above. Use the local definitions of prisms in
+   `Network.AWS.ARN.Internal.Lens`:
 
    ```haskell
    _Function :: Prism' Text Function
    _Function = prism' fromFunction toFunction
    ```
 
-5. Add the records, its fields, its parsing/unparsing functions, and
-   its optics to the service module's export list:
+5. Add the records, their fields, its parsing/unparsing functions, and
+   prisms to the service module's export list:
 
    ```haskell
    module Network.AWS.ARN.Lambda
      ( -- * Functions
        Function (..),
-       toFunction,
-       fromFunction,
+       parseFunction,
+       renderFunction,
 
-       -- ** Function Optics
+       -- ** Prisms
        _Function,
-       fName,
-       fQualifier,
      )
    ```
 

--- a/src/Network/AWS/ARN.hs
+++ b/src/Network/AWS/ARN.hs
@@ -45,10 +45,10 @@
 -- @
 module Network.AWS.ARN
   ( ARN (..),
-    toARN,
-    fromARN,
+    parseARN,
+    renderARN,
 
-    -- * ARN Optics
+    -- * ARN Prism
     _ARN,
 
     -- * Utility Optics
@@ -69,8 +69,8 @@ import GHC.Generics (Generic, Generic1)
 import Network.AWS.ARN.Internal.Lens (Lens', Prism', prism')
 import Text.Show.Deriving (deriveShow1)
 
--- | A parsed ARN. Either use the '_ARN' 'Prism'', or the 'toARN' and
--- 'fromARN' functions to convert @'Text' \<-\> 'ARN'@.  The
+-- | A parsed ARN. Either use the '_ARN' 'Prism'', or the 'parseARN' and
+-- 'renderARN' functions to convert @'Text' \<-\> 'ARN'@.  The
 -- 'resource' part of an ARN will often contain colon- or
 -- slash-separated parts which precisely identify some resource. If
 -- there is no service-specific module (see below), the 'colons' and
@@ -129,8 +129,8 @@ $(deriveShow1 ''ARN)
 
 deriving instance Hashable1 ARN
 
-toARN :: Text -> Maybe (ARN Text)
-toARN t = case T.splitOn ":" t of
+parseARN :: Text -> Maybe (ARN Text)
+parseARN t = case T.splitOn ":" t of
   ("arn" : part : srv : reg : acc : res) ->
     Just $
       ARN
@@ -142,8 +142,8 @@ toARN t = case T.splitOn ":" t of
         }
   _ -> Nothing
 
-fromARN :: ARN Text -> Text
-fromARN arn =
+renderARN :: ARN Text -> Text
+renderARN arn =
   T.intercalate
     ":"
     [ "arn",
@@ -155,7 +155,7 @@ fromARN arn =
     ]
 
 _ARN :: Prism' Text (ARN Text)
-_ARN = prism' fromARN toARN
+_ARN = prism' renderARN parseARN
 {-# INLINE _ARN #-}
 
 -- | Split a 'Text' into colon-separated parts.

--- a/src/Network/AWS/ARN/Lambda.hs
+++ b/src/Network/AWS/ARN/Lambda.hs
@@ -13,10 +13,10 @@
 module Network.AWS.ARN.Lambda
   ( -- * Functions
     Function (..),
-    toFunction,
-    fromFunction,
+    parseFunction,
+    renderFunction,
 
-    -- ** Function Optics
+    -- ** Prisms
     _Function,
   )
 where
@@ -44,8 +44,8 @@ data Function = Function
   }
   deriving (Eq, Ord, Hashable, Show, Generic)
 
-toFunction :: Text -> Maybe Function
-toFunction t = case T.splitOn ":" t of
+parseFunction :: Text -> Maybe Function
+parseFunction t = case T.splitOn ":" t of
   ("function" : nam : qual) ->
     Just (Function nam) <*> case qual of
       [q] -> Just $ Just q
@@ -53,10 +53,10 @@ toFunction t = case T.splitOn ":" t of
       _ -> Nothing
   _ -> Nothing
 
-fromFunction :: Function -> Text
-fromFunction f =
+renderFunction :: Function -> Text
+renderFunction f =
   T.intercalate ":" $
     ["function", name f] ++ maybeToList (qualifier f)
 
 _Function :: Prism' Text Function
-_Function = prism' fromFunction toFunction
+_Function = prism' renderFunction parseFunction

--- a/test/Network/AWS/ARN/Test.hs
+++ b/test/Network/AWS/ARN/Test.hs
@@ -18,14 +18,14 @@ test_all =
     [ testGroup
         "basic tests"
         [ testCase "inspect function name and alias of Lambda ARN" $
-            (resource <$> toARN aliasedLambdaSampleARN)
+            (resource <$> parseARN aliasedLambdaSampleARN)
               @?= Just "function:the-coolest-function-ever:Alias",
           testCase "parses empty region OK" $
-            (region <$> toARN s3FileSampleARN) @?= Just "",
+            (region <$> parseARN s3FileSampleARN) @?= Just "",
           testCase "parses empty account OK" $
-            (account <$> toARN s3FileSampleARN) @?= Just "",
+            (account <$> parseARN s3FileSampleARN) @?= Just "",
           testCase "rejects non-ARNs" $
-            toARN sampleNotAnARN @?= Nothing
+            parseARN sampleNotAnARN @?= Nothing
         ],
       testGroup
         "optic tests"


### PR DESCRIPTION
`toARN :: Text -> Maybe (ARN Text)` and `fromARN :: ARN Text -> Text`
never sat right with me, because they felt backwards compared to their
conventional use. Call them `parseARN` and `renderARN` instead, which
needs much less explanation.

Also fix up the readme to match new conventions.