### PR TITLE
Dependency updates for 2025-10-14

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1755522139,
-        "narHash": "sha256-a650biN/2i36oG5TJVndTklSz50vNuoLFMh67fVvqWQ=",
+        "lastModified": 1760401436,
+        "narHash": "sha256-77cVIdd6w/yXWX4Ys+BUDS+BE2ynZj0iOwkcQvZsnA8=",
         "owner": "bellroy",
         "repo": "bellroy-nix-foss",
-        "rev": "72c4b556f2859a984a1eafed20bcb2027bf8d675",
+        "rev": "e250ce4f1565307993163b8615dcdbd207e68703",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755446520,
-        "narHash": "sha256-I0Ok1OGDwc1jPd8cs2VvAYZsHriUVFGIUqW+7uSsOUM=",
+        "lastModified": 1760392170,
+        "narHash": "sha256-WftxJgr2MeDDFK47fQKywzC72L2jRc/PWcyGdjaDzkw=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4b04db83821b819bbbe32ed0a025b31e7971f22e",
+        "rev": "46d55f0aeb1d567a78223e69729734f3dca25a85",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755268003,
-        "narHash": "sha256-nNaeJjo861wFR0tjHDyCnHs1rbRtrMgxAKMoig9Sj/w=",
+        "lastModified": 1760349414,
+        "narHash": "sha256-W4Ri1ZwYuNcBzqQQa7NnWfrv0wHMo7rduTWjIeU9dZk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "32f313e49e42f715491e1ea7b306a87c16fe0388",
+        "rev": "c12c63cd6c5eb34c7b4c3076c6a99e00fcab86ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Updated bellroy-nix-foss dependency to latest (2025-08-18 → 2025-10-14)
  - git-hooks: 2025-08-17 → 2025-10-13
  - nixpkgs: 2025-08-15 → 2025-10-13
- Cabal file already includes latest GHC versions (up to 9.12.1)

## Test plan
- [x] Review changes
- [x] Verify CI passes with all supported GHC versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)