### PR TITLE
Dependency Update 20260609

### DIFF
--- a/aws-arn.cabal
+++ b/aws-arn.cabal
@@ -45,7 +45,7 @@ tested-with:
    || ==9.6.6
    || ==9.8.2
    || ==9.10.1
-   || ==9.12.1
+   || ==9.12.2
 
 common opts
   default-language: Haskell2010
@@ -58,7 +58,7 @@ common opts
 
 common deps
   build-depends:
-    , base             >=4.12   && <4.22
+    , base             >=4.12   && <4.23
     , deriving-compat  >=0.5.10 && <0.7
     , microlens-pro    ^>=0.2
     , tagged           ^>=0.8
@@ -92,7 +92,7 @@ test-suite spec
     , tasty        ^>=1.4.0.2  || ^>=1.5
     , tasty-hunit  ^>=0.10.0.3
 
-  build-tool-depends: tasty-discover:tasty-discover >=4.2.2 && <5.1
+  build-tool-depends: tasty-discover:tasty-discover >=4.2.2 && <5.3
 
 source-repository head
   type:     git


### PR DESCRIPTION
- base: <4.22 -> <4.23 (admit base 4.22.0.0)
- tasty-discover: <5.1 -> <5.3 (admit 5.2.0)
- tested-with: GHC 9.12.1 -> 9.12.2 (matches flake/CI)